### PR TITLE
Added hashtag-based tiers for payouts, solves #11

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -77,7 +77,7 @@ class Project < ActiveRecord::Base
       tip = Tip.create({
         project: self,
         user: user,
-        amount: next_tip_amount,
+        amount: next_tip_amount * (multiplier_for commit),
         commit: commit.sha
       })
 
@@ -92,6 +92,21 @@ class Project < ActiveRecord::Base
       Rails.logger.info "    Tip created #{tip.inspect}"
     end
 
+  end
+
+  def multiplier_for commit
+    hashtag = commit.commit.message[/#[a-z]*/i]
+
+    if hashtag
+      hashtag = hashtag[1..-1].downcase
+      if CONFIG['tiers'].has_key?(hashtag)
+        CONFIG['tiers'][hashtag]
+      else
+        1
+      end
+    else
+      1
+    end
   end
 
   def available_amount

--- a/config/config.yml.sample
+++ b/config/config.yml.sample
@@ -28,6 +28,16 @@ smtp_settings:
 #   api_key: 111111111111
 #   host: errbit.tip4commit.com
 
+
+# Payout tiers, multipliers on the below tip amount
+tiers:
+  free: 0
+  tiny: 0.1
+  small: 0.5
+  average: 1
+  large: 2
+  huge: 10
+
 tip: 0.01
 min_payout: 100000
 our_fee: 0.05


### PR DESCRIPTION
Tiers will be decided based on the first hashtag encountered in a commit. If there is no hashtag or the hashtag is not in the list of tiers, the multiplier will be 1 (so fully standard). If there is a hashtag in the commit message that matches the tiers in `config.yml`, that multiplier will be applied to the tip amount. I included in `config.yml.sample` the tiers that were discussed in issue #11, but tiers are fully user-configurable.
