### PR TITLE
Fixed margins in nav bar on mobile

### DIFF
--- a/app/assets/stylesheets/justified-nav.css
+++ b/app/assets/stylesheets/justified-nav.css
@@ -27,6 +27,7 @@ body {
   border: 1px solid #ccc;
 }
 .nav-justified > li > a {
+  margin-bottom: 0;
   padding-top: 15px;
   padding-bottom: 15px;
   color: #777;


### PR DESCRIPTION
Removed the margin-bottom rule from:

.nav-justified>li>a of the /assets/application-25b8d7709fc3c19033d1292decf2d537.css:3892 (line 3892)

to remove the empty space at mobile resolutions.
### Before

![Before](http://i.imgur.com/2egBnON.png)
### After

![After](http://i.imgur.com/YHL4TV8.png)

It would obviously be better to remove the original rule which sets the margin-bottom value to "5px" in the first place, depending on whether you prefer this style.
