### PR TITLE
use nickname to link github account to user

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -2,7 +2,8 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def github
     # render text: "#{request.env["omniauth.auth"].to_json}"
     info = request.env["omniauth.auth"]["info"]
-    @user = User.find_by :email => info["email"]
+    @user = User.find_by :nickname => info["nickname"]
+    @user ||= User.find_by :email => info["email"]
     unless @user
       generated_password = Devise.friendly_token.first(8)
       @user = User.create!(


### PR DESCRIPTION
My main email on github is different than the one my commits, so I had 2 accounts (one created when your site saw my commit and another one when I logged in with github). The only way to log in with the one with the tips was to use the link in the email. Otherwise I log in to an empty account.

With this change the user is found by his nickname, not his email. So it should solve the double account.

I won't be able to log in with the empty account anymore, but it doesn't really matters because it's useless.
