### PR TITLE
Verify address version

### DIFF
--- a/config/config.yml.sample
+++ b/config/config.yml.sample
@@ -33,3 +33,7 @@ min_payout: 100000
 our_fee: 0.05
 
 deposit_address: 1M4bS4gPyA6Kb8w7aXsgth9oUZWcRk73tQ
+
+address_versions: # 0/5 for bitcoin addresses, 111/196 for testnet, see chainparams.cpp
+  - 111
+  - 196

--- a/lib/bitcoin_address_validator.rb
+++ b/lib/bitcoin_address_validator.rb
@@ -13,7 +13,15 @@ class BitcoinAddressValidator < ActiveModel::EachValidator
   B58Base = B58Chars.length
 
   def valid_bitcoin_address?(address)
-    (address =~ /^[a-zA-Z1-9]{33,35}$/) and version(address)
+    if (address =~ /^[a-zA-Z1-9]{33,35}$/) and version = version(address)
+      if (expected_versions = CONFIG["address_versions"]).present?
+        expected_versions.include?(version.ord)
+      else
+        true
+      end
+    else
+      false
+    end
   end
 
   def version(address)


### PR DESCRIPTION
Address version is not checked, so someone can put a testnet address or an address of an altcoin. If it happens I think the whole sendmany will fail.

I added options in config to define valid address versions (in case you want to run it on testnet or something else).
