### PR TITLE
Disable password autocomplete on all login/change forms

### DIFF
--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -2,8 +2,8 @@
   %h2 Change your password
   = devise_error_messages!
   = f.hidden_field :reset_password_token
-  = f.password_field :password, :autofocus => true
-  = f.password_field :password_confirmation
+  = f.password_field :password, :autofocus => true, :autocomplete => "off"
+  = f.password_field :password_confirmation, :autocomplete => "off"
   = f.submit "Change my password"
   %p
     = render "devise/shared/links"

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -14,12 +14,12 @@
   %div
     = f.label :password_confirmation
     %br/
-    = f.password_field :password_confirmation
+    = f.password_field :password_confirmation, :autocomplete => "off"
   %div
     = f.label :current_password
     %i (we need your current password to confirm your changes)
     %br/
-    = f.password_field :current_password
+    = f.password_field :current_password, :autocomplete => "off"
   %div= f.submit "Update"
   %p
     %h3 Cancel my account

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -2,8 +2,8 @@
   %h2 Sign up
   = devise_error_messages!
   = f.email_field :email, :autofocus => true
-  = f.password_field :password
-  = f.password_field :password_confirmation
+  = f.password_field :password, :autocomplete => "off"
+  = f.password_field :password_confirmation, :autocomplete => "off"
   = f.submit "Sign up"
   %p
     = render "devise/shared/links"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,7 +1,7 @@
 = twitter_bootstrap_form_for(resource, :as => resource_name, :url => session_path(resource_name), html: {class: 'form-devise' }) do |f|
   %h2 Sign in
   = f.email_field :email, :autofocus => true
-  = f.password_field :password
+  = f.password_field :password, :autocomplete => "off"
   - if devise_mapping.rememberable?
     %div
       = f.check_box :remember_me, "Remember me"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -19,6 +19,6 @@
 
 = twitter_bootstrap_form_for @user, html: {class: (params[:new_password] ? '' : 'collapse'), id: 'new_password_form'} do |f|
   = hidden_field_tag :new_password, :value => true
-  = f.password_field :password, :autofocus => true
-  = f.password_field :password_confirmation
+  = f.password_field :password, :autofocus => true, :autocomplete => "off"
+  = f.password_field :password_confirmation, :autocomplete => "off"
   = f.submit "Change my password"


### PR DESCRIPTION
Password autocompletion is bad for security, especially when the password is all you need to withdraw bitcoins.

There's some further discussion of this on StackExchange: http://security.stackexchange.com/questions/49326/should-websites-be-allowed-to-disable-autocomplete-on-forms-or-fields
