### PR TITLE
Optimize login_token generation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,11 +18,9 @@ class User < ActiveRecord::Base
   	tips.unpaid.sum(:amount)
   end
 
-  after_create :generate_login_token!
-  def generate_login_token!
-    if login_token.blank?
-      self.update login_token: SecureRandom.urlsafe_base64
-    end
+  before_create :set_login_token!, unless: :login_token?
+  def set_login_token!
+    self.login_token = SecureRandom.urlsafe_base64
   end
 
   def full_name


### PR DESCRIPTION
Whenever we are generating the login_token for a user, currently, it is firing 2 queries to the DB, 1 for the 'create' and 1 for the 'update' login_token statement.

If we set the login_token in a :before_create callback we would still have the update within the transaction plus the login_token would get saved in the 'create' statement itself.
