### PR TITLE
removed the 'html' attribute from projects dashboard

### DIFF
--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -1,6 +1,6 @@
 %h1 Supported Projects
 %p
-  = form_tag projects_path, html: {role: 'form', class: 'form-inline"'}, method: :post do |f|
+  = form_tag projects_path, role: 'form', method: :post do |f|
     .form-group
       .row
         .col-lg-10


### PR DESCRIPTION
Previously role attributes is put inside the "html" attributes project find or add form which forming the form as follows:

``` html
<form html="{:role= \"form\";, :class=\"form-inline\"}" accept-charset="UTF-8" action="/projects" method="post">
</form>
```

So i have removed the html attribute and put role attribute in the form. I have removed 'form-inline' class as these class value will make the form size smaller 
