### PR TITLE
Fix- Generating correct html of hidden password field

### DIFF
--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -39,7 +39,7 @@
   %strong= link_to 'Change your password', '#new_password_form', data: {toggle: "collapse"}
 
 = twitter_bootstrap_form_for @user, html: {class: (params[:new_password] ? '' : 'collapse'), id: 'new_password_form'} do |f|
-  = hidden_field_tag :new_password, :value => true
+  = hidden_field_tag :new_password, '', :value => true
   = f.password_field :password, :autofocus => true, :autocomplete => "off"
   = f.password_field :password_confirmation, :autocomplete => "off"
   = f.submit "Change my password"


### PR DESCRIPTION
- Before

``` html
    <input id="new_password" name="new_password" type="hidden" value="{:value=&gt;true}">
```
- After

``` html
    <input id="new_password" name="new_password" type="hidden" value="true">
```
