### PR TITLE
Changed sign-in link section

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -101,7 +101,7 @@ en:
       make_commits_link: make commits
       tell_us_bitcoin_address: "Just %{tell_us_link} your bitcoin address."
       tell_us_link: tell us
-      sign_in: "Just check your email or %{sign_in_link}."
+      sign_in: 'Just check your email or %{sign_in_link}.'
       promote_project: Promote %{project}
       embedding: Embedding
       image_url: "Image URL:"


### PR DESCRIPTION
Changed the quotes from double to single quotes on line 111 to allow the login link to be displayed and not the raw html on the project pages.
