### PR TITLE
add project avatar image to Project index and show pages

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -28,3 +28,5 @@
   padding: 15px;
   margin: 0 auto;
 }
+
+.rjust { text-align: right ; }

--- a/app/assets/stylesheets/projects.css.scss
+++ b/app/assets/stylesheets/projects.css.scss
@@ -2,6 +2,8 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-.commit-sha {
-  font-family: monospace;
-}
+.commit-sha { font-family: monospace; }
+
+.project_avatar_img                 { position: relative ; width: 32px ; height: 32px ; }
+#projects_table .project_avatar_img { top: 3px ; }
+#project_header .project_avatar_img { top: -5px ; }

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -19,14 +19,29 @@ class Project < ActiveRecord::Base
 
   # before_save :check_tips_to_pay_against_avaiable_amount
 
+  def update_bitcoin_address
+    blockchain_uri       = URI BLOCKCHAIN_NEW_URL
+    blockchain_pass      = CONFIG["blockchain_info"]["password"]
+    blockchain_label     = "#{self.full_name}@tip4commit"
+    blockchain_params    = { password: blockchain_pass, label: blockchain_label }
+    blockchain_uri.query = URI.encode_www_form blockchain_params
+    blockchain_resp      = Net::HTTP.get_response blockchain_uri
+    if blockchain_resp.is_a? Net::HTTPSuccess
+      self.bitcoin_address = (JSON.parse blockchain_resp.body)["address"]
+      self.save! unless self.bitcoin_address.nil?
+    end
+  end
+
   def update_repository_info repo
-    self.github_id = repo.id
-    self.name = repo.name
-    self.full_name = repo.full_name
+    self.github_id        = repo.id
+    self.name             = repo.name
+    self.full_name        = repo.full_name
     self.source_full_name = repo.source.full_name rescue ''
-    self.description = repo.description
-    self.watchers_count = repo.watchers_count
-    self.language = repo.language
+    self.description      = repo.description
+    self.watchers_count   = repo.watchers_count
+    self.language         = repo.language
+    self.avatar_url       = repo.organization.rels[:avatar].href if repo.organization.present?
+
     self.save!
   end
 

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -11,9 +11,10 @@
               = button_tag t('.find_project.button'), class: "btn btn-default", name: nil
 %p
   - if @projects.count > 0
-    %table.table.table-striped
+    %table.table.table-striped#projects_table
       %thead
         %tr
+          %th
           %th= link_to_unless_current t('.repository'), params.merge(:order => 'repository')
           %th= link_to_unless_current t('.description'), params.merge(:order => 'description')
           %th= link_to_unless_current t('.watchers'), params.merge(:order => 'watchers')
@@ -23,6 +24,8 @@
         - @projects.each do |project|
           %tr
             %td
+              = image_tag project.avatar_url , class: 'project_avatar_img' if project.avatar_url
+            %td
               %strong= link_to project.full_name, pretty_project_path(project)
               - if !project.source_full_name.blank?
                 %br
@@ -31,8 +34,8 @@
                     = t('.forked_from')
                     = link_to project.source_full_name, project.source_github_url, target: '_blank'
             %td= project.description
-            %td= project.watchers_count
-            %td= btc_human project.available_amount_cache
+            %td.rjust= project.watchers_count
+            %td.rjust= btc_human project.available_amount_cache
             %td= link_to t('.support'), pretty_project_path(project), class: 'btn btn-xs btn-success'
     = paginate @projects
   - else

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -6,9 +6,9 @@
 - if @project.disable_notifications
   .alert.alert-danger= t('.disabled_notifications')
 
-%h1
-  = @project.full_name
-  %small= link_to glyph(:github), @project.github_url, target: '_blank'
+%h1#project_header
+  = (@project.avatar_url.nil?)? (glyph :github) : (image_tag @project.avatar_url , class: 'project_avatar_img')
+  = link_to @project.full_name , @project.github_url, target: '_blank'
   .pull-right
     - if can? :update, @project
       = link_to t('.edit_project'), edit_project_path(@project), class: "btn btn-primary"

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,0 +1,4 @@
+
+BLOCKCHAIN_BASE_URL = "https://blockchain.info/merchant"
+BLOCKCHAIN_GUID     = CONFIG['blockchain_info']['guid']
+BLOCKCHAIN_NEW_URL  = "#{BLOCKCHAIN_BASE_URL}/#{BLOCKCHAIN_GUID}/new_address"

--- a/db/migrate/20141019200525_add_avatar_to_projects.rb
+++ b/db/migrate/20141019200525_add_avatar_to_projects.rb
@@ -1,0 +1,5 @@
+class AddAvatarToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :avatar_url, :string
+  end
+end


### PR DESCRIPTION
this PR is a consolidation of the commits from PR #126
based on the current master branch
- added :avatar_url field to Project table for efficiency
- project avatar image replaces octocat on Project show page
- project avatar url updates in Project#update_repository_info
- refactored ProjectsController#show action
- extracted #show action redirect before_filter into ProjectsController#redirect_to_pretty_url
- refactored bitcoin address update procedure to split long lines
    and abstract some magic numbers into config/initializers/constants.rb
- extracted bitcoin address update procedure into Project#update_bitcoin_address
