### PR TITLE
add cross-dev Gemfile and update 'bootstrap_form' gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'octokit',         '~> 2.7.0'
 gem 'sawyer',          '~> 0.5.2'
 gem 'twitter_bootstrap_form_for', github: 'stouset/twitter_bootstrap_form_for'
 gem 'twitter-bootstrap-rails',    github: 'seyhunak/twitter-bootstrap-rails', branch: 'bootstrap3'
-gem 'bootstrap_form', github: 'sigmike/rails-bootstrap-forms', branch: 'removed_for_on_radio_label'
+gem 'bootstrap_form', github: 'bootstrap-ruby/rails-bootstrap-forms'
 gem 'sdoc', group: :doc, require: false
 gem 'cancancan'
 gem 'dusen'

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Donate bitcoins to open source projects or receive tips for code contributions.
 Developers
 ==========
 
-If you would like to contribute to the development of tip4commit, you can find the contribution guidelines and installation instructions on the [developer README](https://github.com/tip4commit/tip4commit/wiki/README---Developers)
+If you would like to contribute to the development of tip4commit, you can find the contribution guidelines and installation instructions on the [developer README](https://github.com/tip4commit/tip4commit/wiki/Developer-README)
 
 
 License

--- a/config/cross-fork-dev/Gemfile.dev
+++ b/config/cross-fork-dev/Gemfile.dev
@@ -1,0 +1,174 @@
+=begin
+  ** DO NOT COMMIT THIS FILE IN THE RAILS ROOT DIR **
+  bundle then then restore the original
+      (see: config/cross-fork-dev/cross-fork-dev-REAMDE.md)
+      cd RAILS_ROOT
+      mv Gemfile                           ./Gemfile.bak
+      cp config/cross-fork-dev/Gemfile.dev ./Gemfile
+      bundle install --without production mysql postgresql
+      mv Gemfile.bak                       ./Gemfile
+=end
+
+
+source 'https://rubygems.org'
+
+ruby '2.0.0'
+
+gem 'rails',           '4.0.2'
+gem 'mysql2',                      group: :production
+gem 'sass-rails',      '~> 4.0.0'
+gem 'haml-rails',      '~> 0.5.3'
+gem 'less-rails',      '~> 2.4.2'
+gem 'kaminari',        '~> 0.15.0'
+gem 'uglifier',        '>= 1.3.0'
+gem 'coffee-rails',    '~> 4.0.0'
+gem 'therubyracer',    '~> 0.12.0', platforms: :ruby
+gem 'jquery-rails',    '~> 3.0.4'
+gem 'turbolinks',      '~> 2.2.0'
+gem 'jquery-turbolinks'
+gem 'jbuilder',        '~> 1.5.3'
+gem 'airbrake',        '~> 3.1.15'
+gem 'devise',          '~> 3.2.2'
+gem 'omniauth',        '~> 1.1.4'
+gem 'omniauth-github', github: 'alexandrz/omniauth-github', branch: 'provide_emails'
+gem 'octokit',         '~> 2.7.0'
+gem 'sawyer',          '~> 0.5.2'
+gem 'twitter_bootstrap_form_for', github: 'stouset/twitter_bootstrap_form_for'
+gem 'twitter-bootstrap-rails',    github: 'seyhunak/twitter-bootstrap-rails', branch: 'bootstrap3'
+# sigmike 'bootstrap_form' bugfix added in https://github.com/tip4commit/tip4commit/pull/74
+#   has been merged upstream https://github.com/bootstrap-ruby/rails-bootstrap-forms/pull/76
+#gem 'bootstrap_form', github: 'sigmike/rails-bootstrap-forms', branch: 'removed_for_on_radio_label'
+gem 'bootstrap_form', github: 'bootstrap-ruby/rails-bootstrap-forms'
+gem 'sdoc', group: :doc, require: false
+gem 'cancancan'
+gem 'dusen'
+gem 'render_csv'
+gem 'demoji'
+
+gem "http_accept_language"
+gem 'rails-i18n'
+gem "i18n-js"
+gem 'kaminari-i18n'
+gem 'devise-i18n'
+
+group :development do
+  gem 'capistrano',         '~> 3.0.1'
+  gem 'capistrano-rvm',     '~> 0.1.0', github: 'capistrano/rvm'
+  gem 'capistrano-bundler', '>= 1.1.0'
+  gem 'capistrano-rails',   '~> 1.1.0'
+  gem 'debugger',           '~> 1.6.5'
+end
+
+group :development, :test do
+  gem 'sqlite3',            '~> 1.3.8'
+  gem 'factory_girl_rails', '~> 4.3.0'
+  gem 'rspec-rails',        '~> 3.0.0.beta'
+end
+
+group :test do
+  gem 'simplecov'
+  gem 'shoulda-matchers',   '~> 2.5.0'
+  gem 'cucumber-rails', require: false
+  gem 'database_cleaner'
+end
+
+
+
+
+
+
+
+# peer4commit
+
+source 'https://rubygems.org'
+
+# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
+gem 'rails', '4.0.2'
+
+# Databases
+gem 'sqlite3', '~> 1.3.8' , group: :development
+gem 'mysql2',               group: :mysql
+gem 'pg',                   group: :postgresql
+
+# Use SCSS for stylesheets
+gem 'sass-rails', '~> 4.0.0'
+gem 'haml-rails', '~> 0.5.3'
+gem "less-rails", '~> 2.4.2'
+
+gem 'twitter-bootstrap-rails', github: 'seyhunak/twitter-bootstrap-rails', branch: 'bootstrap3'
+
+gem 'kaminari', '~> 0.15.0'
+
+# Use Uglifier as compressor for JavaScript assets
+gem 'uglifier', '>= 1.3.0'
+
+# Use CoffeeScript for .js.coffee assets and views
+gem 'coffee-rails', '~> 4.0.0'
+
+# See https://github.com/sstephenson/execjs#readme for more supported runtimes
+gem 'therubyracer', '~> 0.12.0', platforms: :ruby
+
+# Use jquery as the JavaScript library
+gem 'jquery-rails', '~> 3.0.4'
+
+# Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
+gem 'turbolinks', '~> 2.2.0'
+
+# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
+gem 'jbuilder', '~> 1.5.3'
+
+group :doc do
+  # bundle exec rake doc:rails generates the API under doc/api.
+  gem 'sdoc', require: false
+end
+
+gem 'devise',   '~> 3.2.2'
+gem 'omniauth', '~> 1.1.4'
+gem 'omniauth-github', github: 'alexandrz/omniauth-github', branch: 'provide_emails'
+gem 'cancancan'
+gem 'twitter_bootstrap_form_for', github: 'stouset/twitter_bootstrap_form_for'
+
+gem 'octokit', '~> 2.7.0'
+
+# Use ActiveModel has_secure_password
+# gem 'bcrypt-ruby', '~> 3.0.0'
+
+# Use unicorn as the app server
+# gem 'unicorn'
+
+# Use debugger
+# gem 'debugger', group: [:development, :test]
+
+group :development do
+  gem 'capistrano',         '~> 3.0.1'
+  gem 'capistrano-rvm',     '~> 0.1.0', github: 'capistrano/rvm'
+  gem 'capistrano-bundler', '>= 1.1.0'
+  gem 'capistrano-rails',   '~> 1.1.0'
+  gem 'quiet_assets'
+end
+
+gem 'airbrake', '~> 3.1.15'
+gem 'httparty'
+gem 'whenever'
+gem 'rqrcode-rails3'
+gem 'exception_notification'
+gem 'rack-canonical-host'
+gem 'bootstrap_form', github: 'bootstrap-ruby/rails-bootstrap-forms'
+gem 'html_pipeline_rails'
+gem 'rails_autolink'
+gem 'redcarpet'
+gem 'sanitize'
+gem 'twitter-typeahead-rails'
+gem 'commontator', '~> 4.6.0'
+gem 'compass-rails'
+
+group :test do
+  gem 'cucumber-rails', :require => false
+  # database_cleaner is not required, but highly recommended
+  gem 'database_cleaner'
+  gem 'rspec-rails',        '~> 3.0.0.beta'
+  gem 'factory_girl_rails', '~> 4.3.0'
+  gem 'poltergeist'
+  gem 'timecop'
+  gem 'capybara-screenshot'
+end

--- a/config/cross-fork-dev/config.yml.dev
+++ b/config/cross-fork-dev/config.yml.dev
@@ -8,7 +8,7 @@ PRIME4COMMIT_BRANCHES   = %w{prime4commit-master peer4commit-new-feature}
 BRANCHES_LISTS_FILENAME = 'config/config.yml' # DEBUG
 
 BRANCH_NAME          = `git rev-parse --abbrev-ref HEAD`.strip
-IS_MYFORK            = MY_BRANCHES.include?           BRANCH_NAME
+IS_MY_FORK           = MY_BRANCHES.include?           BRANCH_NAME
 IS_TIP4COMMIT_FORK   = TIP4COMMIT_BRANCHES.include?   BRANCH_NAME
 IS_PEER4COMMIT_FORK  = PEER4COMMIT_BRANCHES.include?  BRANCH_NAME
 IS_PRIME4COMMIT_FORK = PRIME4COMMIT_BRANCHES.include? BRANCH_NAME

--- a/config/cross-fork-dev/cross-fork-dev-REAMDE.md
+++ b/config/cross-fork-dev/cross-fork-dev-REAMDE.md
@@ -2,7 +2,14 @@
 
 the files in this directory exist to aid cross-fork development of the various tip4commit forks from within the same local clone - if you will be working on only one fork then use Gemfile, config/config.yml.sample, and config/database.yml.sample instead
 
-the various forks have drifted apart significantly and require different configuratons - these files will allow these all to be functional within in the same clone without manual config swapping - the only routine maintenance required is in adding new feature branches to the appropriate *_BRANCHES list in config.yml.dev and re-bundling when switching between forks
+the various forks have drifted apart significantly and require different configuratons - these files will allow these all to be functional within in the same clone without manual config swapping - the only routine maintenance required is in adding new feature branches to the appropriate *_BRANCHES list in config.yml.dev and re-bundling when Gemfiles change
+
+
+#### config/cross-fork-dev/Gemfile.dev
+
+Gemfile.dev is a concatenation of the Gemfiles from the tip4commit and peer4commit forks with some version conflicts resolved by favoring the more specific requirement
+
+this o/c is brittle and must be maintained and is not guaranteed 100% bug-free but has so far worked out well for development
 
 
 #### config/cross-fork-dev/config.yml.dev
@@ -13,14 +20,25 @@ the various forks have drifted apart significantly and require different configu
 
 
 #### config/cross-fork-dev/database.yml.dev
+
   database.yml.dev also includes a separate configuration for each known tip4commit variant - switched per the current git branch (requires the *_BRANCHES list in config.yml.dev)
 
 
 ### setup
 
   * fork any of the tip4commit forks then clone your fork
-  * copy config/cross-fork-dev/config.yml.dev to config/config.yml and
-    copy config/cross-fork-dev/database.yml.dev to config/database.yml
+  * backup Gemfile then copy Gemfile.dev to the rails root dir
+```
+      cd RAILS_ROOT
+      mv Gemfile                           ./Gemfile.bak
+      cp config/cross-fork-dev/Gemfile.dev ./Gemfile
+```
+  * bundle then restore Gemfile
+```
+      bundle install --without production mysql postgresql
+      mv Gemfile.bak ./Gemfile
+```
+  * copy config.yml.dev and database.yml.dev to config
 ```
       cp config/cross-fork-dev/config.yml.dev   config/config.yml
       cp config/cross-fork-dev/database.yml.dev config/database.yml
@@ -28,22 +46,23 @@ the various forks have drifted apart significantly and require different configu
   * customize config/config.yml and config/database.yml
   * repeat the following flow for each fork including the one you forked from
 ```
-    git remote add tip4commit https://github.com/tip4commit/tip4commit.git
-    git checkout -b tip4commit-master
-    git fetch tip4commit
-    git merge tip4commit/master
+      git remote add tip4commit https://github.com/tip4commit/tip4commit.git
+      git checkout -b tip4commit-master
+      git fetch tip4commit
+      git merge tip4commit/master
 ```
   * add each fork branch created above its corresponding *_BRANCHES list
 
 
 ### maintenance
+
   * add new local feature branches in their appropriate *_BRANCHES lists
       (e.g. to reduce ambiguity use your local master branch for experimentaion only)
-  * re-bundle each time you switch to a new fork configuration
+  * re-bundle as above when any of the forked Gemfiles change (updating and committing config/cross-fork-dev/Gemfile.dev if necessary)
 ```
-      # for tip4commit
-      bundle install --without production
-
-      # for peer4commit amd prime4commit
-      bundle install --without mysql postgresql
+      cd RAILS_ROOT
+      mv Gemfile                           ./Gemfile.bak
+      cp config/cross-fork-dev/Gemfile.dev ./Gemfile
+      bundle install --without production mysql postgresql
+      mv Gemfile.bak                       ./Gemfile
 ```


### PR DESCRIPTION
- added cross-dev Gemfile
- fixed some typos
- updated dev wiki link in README.md
- updated 'bootstrap_form' gem in Gemfile

the 'sigmike/bootstrap_form' gem added to the Gemfile in PR #74 has been merged upstream (https://github.com/bootstrap-ruby/rails-bootstrap-forms/pull/76)
  it was added apparently as a bugfix but is now quite outdated - it was upgraded in the peer4commit repo in june https://github.com/sigmike/peer4commit/commit/608980f7bd7b9fde5366180142f050d7baaf27a1
