### PR TITLE
Developers must opt-in to receive tips.

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -117,7 +117,9 @@ class Project < ActiveRecord::Base
   def tip_for commit
     if (next_tip_amount > 0) && !Tip.exists?(commit: commit.sha)
 
-      user = User.find_or_create_with_commit commit
+      user = User.find_by_commit(commit)
+      return unless user
+
       user.update(nickname: commit.author.login) if commit.author.try(:login)
 
       if hold_tips

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,17 +50,11 @@ class User < ActiveRecord::Base
     end
   end
 
-  def self.find_or_create_with_commit commit
-    author = commit.commit.author
+  def self.find_by_commit(commit)
+    email = commit.commit.author.email
     nickname = commit.author.try(:login)
-    user = find_by(nickname: nickname) if nickname
-    user || where(email: author.email).first_or_create do |user|
-      user.email    = author.email
-      user.password = Devise.friendly_token.first(Devise.password_length.min)
-      user.name     = author.name
-      user.nickname = nickname
-      user.skip_confirmation!
-    end
+
+    find_by(email: email) || find_by(nickname: nickname)
   end
 
   private

--- a/features/developer_opt_in_for_tips.feature
+++ b/features/developer_opt_in_for_tips.feature
@@ -1,0 +1,23 @@
+Feature: Developers must opt-in to create an account and receive tips
+  Background:
+    Given a project "my-project"
+    And our fee is "0"
+    And a deposit of "500"
+    And the last known commit is "COMMIT1"
+
+  Scenario: Tipping a opted-in developer
+    And a user "yugo" has opted-in
+    And a new commit "COMMIT2" with parent "COMMIT1"
+    And the author of commit "COMMIT2" is "yugo"
+    And the message of commit "COMMIT2" is "Tiny change"
+    When the new commits are read
+    Then there should be a tip of "5" for commit "COMMIT2"
+    And there should be 1 email sent
+
+  Scenario: Tipping a developer that has not opted-in
+    And a new commit "COMMIT2" with parent "COMMIT1"
+    And the author of commit "COMMIT2" is "yugo"
+    And the message of commit "COMMIT2" is "Tiny change"
+    When the new commits are read
+    Then there should be no tip for commit "COMMIT2"
+    And there should be 0 email sent

--- a/features/step_definitions/common.rb
+++ b/features/step_definitions/common.rb
@@ -29,6 +29,15 @@ Given(/^a project "(.*?)"$/) do |arg1|
   @project = Project.create!(full_name: "example/#{arg1}", github_id: Digest::SHA1.hexdigest(arg1), bitcoin_address: 'mq4NtnmQoQoPfNWEPbhSvxvncgtGo6L8WY')
 end
 
+Given(/^a user "(.*?)" has opted\-in$/) do |arg1|
+  User.find_or_create_by!(nickname: arg1) do |user|
+    user.nickname = arg1
+    user.password = "password"
+    user.email = "#{arg1.parameterize}@example.com"
+    user.skip_confirmation!
+  end
+end
+
 Given(/^a deposit of "(.*?)"$/) do |arg1|
   Deposit.create!(project: @project, amount: arg1.to_d * 1e8, confirmations: 2)
 end
@@ -48,6 +57,14 @@ def add_new_commit(id, params = {})
       },
     },
   }
+
+  User.find_or_create_by(email: "anonymous@example.com") do |user|
+    user.nickname = "anonymous"
+    user.email = "anonymous@example.com"
+    user.password = "password"
+    user.skip_confirmation!
+  end
+
   @new_commits[id] = defaults.deep_merge(params)
 end
 

--- a/features/step_definitions/web.rb
+++ b/features/step_definitions/web.rb
@@ -1,10 +1,12 @@
 Given(/^I'm logged in as "(.*?)"$/) do |arg1|
+  email = "#{arg1.parameterize}@example.com"
+
   OmniAuth.config.test_mode = true
   OmniAuth.config.mock_auth[:github] = {
     "info" => {
       "nickname" => arg1,
-      "primary_email" => "#{arg1.gsub(/\s+/,'')}@example.com",
-      "verified_emails" => [],
+      "primary_email" => email,
+      "verified_emails" => [email],
     },
   }.to_ostruct
   visit root_path

--- a/features/tip_modifier_interface.feature
+++ b/features/tip_modifier_interface.feature
@@ -1,6 +1,8 @@
 Feature: A project collaborator can change the tips of commits
   Background:
     Given a project "a"
+    And a user "yugo" has opted-in
+    And a user "gaal" has opted-in
     And the project collaborators are:
       | seldon  |
       | daneel  |


### PR DESCRIPTION
This should stop creating user accounts for developers who just happen to commit to a project being watched by T4C. Additional work will need to be done to remove existing accounts (delete everything that doesn't have a bitcoin address?).

Fixes: #154
Related: #157 
