### PR TITLE
supress visibility of unclaimed tips (issue #146)

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -40,8 +40,8 @@ class ProjectsController < ApplicationController
         @project.update_attribute :bitcoin_address, bitcoin_address
       end
     end
-    @project_tips = @project.tips
-    @recent_tips  = @project_tips.includes(:user).order(created_at: :desc).first(5)
+    @project_tips = @project.tips.with_address
+    @recent_tips  = @project_tips.with_address.order(created_at: :desc).first(5)
   end
 
   def edit

--- a/app/controllers/tips_controller.rb
+++ b/app/controllers/tips_controller.rb
@@ -4,11 +4,16 @@ class TipsController < ApplicationController
 
   def index
     if params[:project_id]
-      @tips = @project.tips.includes(:user)
+      @tips = @project.tips.includes(:user).with_address
     elsif params[:user_id] && @user = User.find(params[:user_id])
+      if @user.nil? || @user.bitcoin_address.blank?
+        flash[:error] = I18n.t('errors.user_not_found')
+        redirect_to users_path and return
+      end
+
       @tips = @user.tips.includes(:project)
     else
-      @tips = Tip.includes(:user, :project)
+      @tips = Tip.with_address.includes(:project)
     end
     @tips = @tips.order(created_at: :desc).
                   page(params[:page]).

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
   end
 
   def index
-    @users = User.order(withdrawn_amount: :desc, commits_count: :desc).where('commits_count > 0').page(params[:page]).per(30)
+    @users = User.order(withdrawn_amount: :desc, commits_count: :desc).where('commits_count > 0 AND withdrawn_amount > 0').page(params[:page]).per(30)
   end
 
   def update

--- a/app/views/tips/index.html.haml
+++ b/app/views/tips/index.html.haml
@@ -37,8 +37,6 @@
                 = t('.refunded')
               - elsif tip.undecided?
                 = t('.undecided')
-              - elsif tip.user.bitcoin_address.blank?
-                = t('.no_bitcoin_address')
               - elsif tip.user.balance < CONFIG["min_payout"]
                 = t('.below_threshold')
               - else


### PR DESCRIPTION
- filtered all Tips relations through the Tips:with_address scope
    except for UsersController#show (private page)
- filtered users with zero withdrawn_amount in UsersController#index
- removed :no_bitcoin_address message from Tips#index

NOTES:

i do not have a full setup (blockchain account , etc) so i could not test this feature manually - it was implemented driven by cucumber tests which are not included in this PR because they were implemented on the tip of my HEAD using an incompatible routing/testing scheme implemented in PR #141 and would cause travis to fail today - they are included in PR #142 along with tests for several other recent features pending merge of the new pretty url routing scheme

regarding the TipsController#index action switched on no params -
  # the original query
  Tip.includes(:user , :project)
  # the replacement query
  Tip.with_address.includes(:project)
the Tips:with_address scope joins(:user) so this should not have broken anything but unfortunately no tests exist for the Tips view so this should be verified manually on a staging system

regarding the UsersController#index action -
im a bit uncertain of the semantics here but the User :withdrawn_amount is based on the tips.paid scope which is based on the existence of a :sendmany_id - so im assuming that this means that a tip that was offered to someone without bitcoin_address would not have a sendmany_id and any so such user would have a zero withdrawn_amount
