### PR TITLE
Blacklist my personal (mpasternacki) and my organization's (3ofcoins) repos

### DIFF
--- a/config/blacklist.yml
+++ b/config/blacklist.yml
@@ -28,3 +28,5 @@
 - https://github.com/joomla-projects/*
 - https://github.com/ForumPostAssistant/FPA
 - https://github.com/ipython/*
+- https://github.com/mpasternacki/*
+- https://github.com/3ofcoins/*


### PR DESCRIPTION
I am owner of the _3ofcoins_ org - if this needs any extra verification (or a separate pull request from a clone in the org), please let me know.

By the way, this process improves your  project's github stats (# of forks) by requiring people who are _actively against what are you doing_ to create a fork, and to opt-out (and I'm pretty sure most of the owners of listed projects are not even aware of t4c's existence). This project should be opt-in, not opt-out. If somebody wants to add a project, it should at most send an invitation to project's owner they'd need to **explicitly confirm** (Cc: #165 #152). There are tax issues involved on the receivers' side too.
