### PR TITLE
Use a panel for project descriptions

### DIFF
--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -34,7 +34,8 @@
 
   .col-md-8
     - unless @project.description.blank?
-      .well.well-sm= @project.description
+      .panel.panel-default
+        .panel-body= @project.description
     %h4
       = t('.balance')
       - if @project.deposits.count > 0


### PR DESCRIPTION
When project descriptions were inside a well, the upper portion of a project page was a sea of grayscale boxes. Putting project descriptions inside Bootstrap panels instead of wells lightens up the layout and makes the description more noticeable.