### PR TITLE
Fix render flash messages

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -163,8 +163,8 @@ module ApplicationHelper
     html = []
     flash.each do |_type, _message|
       alert_type = case _type
-        when :notice         then :success
-        when :alert, :error  then :danger
+        when 'notice'         then :success
+        when 'alert', 'error' then :danger
       end
       html << content_tag(:div, class: "alert alert-#{alert_type}"){ _message }
     end


### PR DESCRIPTION
Fix applying color in render flash messages

The message will be shown as the image below:

![screenshot1](https://cloud.githubusercontent.com/assets/26974372/26255810/39e0e38c-3c91-11e7-90b8-01b9b46db40c.png)

Instead of appearing as is in prod (no color):

![screenshot2](https://cloud.githubusercontent.com/assets/26974372/26256025/f4388104-3c91-11e7-8ff8-bce8211d4283.png)

