### PR TITLE
Use .ruby-version file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,19 +10,15 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     strategy:
-      matrix:
-        ruby-version:
-          - 3.2.6
       fail-fast: false
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name: Set up Ruby ${{ matrix.ruby-version }}
+    - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
 
     - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@
 /config/config.yml
 
 /public/assets
-.ruby-version
 .rspec
 
 coverage

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,6 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 3.2
   NewCops: enable
   Exclude:
     - 'db/schema.rb'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -8,7 +8,7 @@ set :repo_url, 'git@github.com:tip4commit/tip4commit.git'
 set :deploy_to, '/home/apps/t4c'
 
 set :rvm_type, :user
-set :rvm_ruby_version, '3.2.6'
+set :rvm_ruby_version, File.read("#{File.dirname(__FILE__)}/../.ruby-version").strip
 set :rvm_custom_path, '~/.rvm'
 
 set :format, :pretty


### PR DESCRIPTION
This is pretty much the community standard now, and is supported by all the major version managers (rbenv, rvm, chruby, etc.) and tooling (Rubocop, the `ruby/setup-ruby@v1` GitHub action, etc.)

Makes it a little more seamless to get up and running to make contributions.